### PR TITLE
Fix Markup import, update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ Dieses Repository enthält den Code für einen digitalen Adventskalender, spezie
 3. Klonen Sie das Repository und navigieren Sie in das Projektverzeichnis.
 4. Starten Sie den Server:
    ```bash
-   python app.py
+   python advent.py
    ```
 5. Öffnen Sie einen Webbrowser und gehen Sie zu `http://localhost:8087/`.
 
 ## Konfiguration
 
-- Sie können die Uhrzeiten für die Gewinnvergabe in der Datei `app.py` anpassen.
-- Die Farben der Türchen können ebenfalls in `app.py` geändert werden.
+- Sie können die Uhrzeiten für die Gewinnvergabe in der Datei `advent.py` anpassen.
+- Die Farben der Türchen können ebenfalls in `advent.py` geändert werden.
 
 ## Sicherheitshinweise
 

--- a/advent.py
+++ b/advent.py
@@ -8,7 +8,8 @@ import random
 import qrcode
 import os
 import pytz
-from flask import Flask, request, make_response, render_template_string, send_from_directory, Markup
+from flask import Flask, request, make_response, render_template_string, send_from_directory
+from markupsafe import Markup
 
 # Logging-Konfiguration
 logging.basicConfig(filename='debug.log', level=logging.DEBUG, 


### PR DESCRIPTION
## Summary
- fix deprecated Markup import
- update README instructions

## Testing
- `pip install Flask qrcode`
- `pip install pytz`
- `python -m py_compile advent.py`
- `python advent.py` (start server, then Ctrl+C)

------
https://chatgpt.com/codex/tasks/task_e_684f1734cf0c8321bf2f03174d74c3e3