### PR TITLE
Add winner import identity matching and placeholder migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,26 @@ Dieses Repository enthält den Code für einen digitalen Adventskalender, spezie
 
 > Hinweis: Die SQLite-Datenbank `users.db` wird bei Bedarf automatisch im Projektverzeichnis angelegt und ist daher nicht im Repository enthalten.
 
+### Import von Gewinnern
+
+- Beim Einlesen der Datei `gewinner.txt` werden vorhandene Nutzer anhand stabiler Merkmale gesucht, bevor Platzhalter-Konten angelegt werden. Dafür werden die E-Mail-Adresse (falls in der Gewinnerzeile mit `email:` hinterlegt), der Display-Name sowie optionale Einträge in `gewinner_user_mapping.json` genutzt.
+- Die optionale Mapping-Datei kann entweder eine Liste oder ein Objekt mit dem Schlüssel `mappings` enthalten. Jedes Mapping unterstützt die Felder `winner_id` (alte ID aus `gewinner.txt`), `display_name`, `email` und die Ziel-`user_id`.
+- Formatbeispiel:
+
+  ```json
+  {
+    "mappings": [
+      {"winner_id": 42, "user_id": 7},
+      {"display_name": "Max Mustermann", "user_id": 5},
+      {"email": "max@example.com", "user_id": 5}
+    ]
+  }
+  ```
+
+### Wartung: Platzhalter bereinigen
+
+- Bereits importierte Gewinne können mit `python advent.py migrate_placeholder_rewards` auf erkannte echte Nutzer-IDs umgehängt werden. Dabei werden Platzhalter-Accounts mit `@example.invalid` entfernt, sobald keine Gewinne mehr auf sie verweisen.
+
 ## Konfiguration
 
 - Sie können die Uhrzeiten für die Gewinnvergabe in der Datei `advent.py` anpassen.

--- a/test_winner_import_matching.py
+++ b/test_winner_import_matching.py
@@ -1,0 +1,91 @@
+import sqlite3
+
+import advent
+
+
+def create_default_schema(connection):
+    connection.execute(
+        """
+        CREATE TABLE users (
+            id INTEGER PRIMARY KEY,
+            email TEXT UNIQUE NOT NULL,
+            display_name TEXT NOT NULL,
+            password_hash TEXT NOT NULL
+        )
+        """
+    )
+    connection.execute(advent.USER_REWARDS_TABLE_SQL)
+
+
+def test_import_prefers_existing_user_by_display_name(tmp_path, monkeypatch):
+    database_path = tmp_path / "users.db"
+    winners_file = tmp_path / "gewinner.txt"
+
+    winners_file.write_text("99: Test User - Tag 1 - Preis\n", encoding="utf-8")
+
+    monkeypatch.setattr(advent, "USER_DATABASE", str(database_path))
+    monkeypatch.setattr(advent, "WINNERS_FILE", str(winners_file))
+
+    with sqlite3.connect(database_path) as connection:
+        connection.row_factory = sqlite3.Row
+        create_default_schema(connection)
+        connection.execute(
+            "INSERT INTO users (id, email, display_name, password_hash) VALUES (?, ?, ?, ?)",
+            (2, "test@example.com", "Test User", ""),
+        )
+
+        imported = advent.import_rewards_from_winners_file(connection, str(winners_file))
+
+        cursor = connection.execute("SELECT user_id, door FROM user_rewards")
+        stored_entries = [tuple(row) for row in cursor.fetchall()]
+
+    assert imported == 1
+    assert stored_entries == [(2, 1)]
+
+
+def test_placeholder_rewards_migration(tmp_path):
+    database_path = tmp_path / "users.db"
+    mapping_file = tmp_path / "gewinner_user_mapping.json"
+
+    mapping_file.write_text(
+        '[{"winner_id": 99, "user_id": 1, "display_name": "Real User"}]',
+        encoding="utf-8",
+    )
+
+    with sqlite3.connect(database_path) as connection:
+        connection.row_factory = sqlite3.Row
+        create_default_schema(connection)
+        connection.execute(
+            "INSERT INTO users (id, email, display_name, password_hash) VALUES (?, ?, ?, ?)",
+            (1, "real@example.com", "Real User", ""),
+        )
+        connection.execute(
+            "INSERT INTO users (id, email, display_name, password_hash) VALUES (?, ?, ?, ?)",
+            (99, "user-99@example.invalid", "Real User", ""),
+        )
+        connection.execute(
+            """
+            INSERT INTO user_rewards (
+                user_id, door, prize_name, sponsor, sponsor_link, qr_filename, qr_content, created_at
+            ) VALUES (?, ?, ?, NULL, NULL, NULL, NULL, datetime('now'))
+            """,
+            (99, 1, "Preis"),
+        )
+
+        migrated, removed = advent.migrate_placeholder_user_rewards(connection, str(mapping_file))
+
+        migrated_entries = [
+            tuple(row)
+            for row in connection.execute(
+                "SELECT user_id, door FROM user_rewards ORDER BY id"
+            ).fetchall()
+        ]
+        remaining_users = [
+            tuple(row)
+            for row in connection.execute("SELECT id FROM users ORDER BY id").fetchall()
+        ]
+
+    assert migrated == 1
+    assert removed == 1
+    assert migrated_entries == [(1, 1)]
+    assert remaining_users == [(1,)]


### PR DESCRIPTION
## Summary
- add lookup strategy to match winners to existing users using display names, emails, or mapping file before creating placeholders
- provide migration utility to reassign placeholder rewards to identified user accounts and clean up orphaned placeholders
- document the new mapping format and add tests covering identity matching and placeholder migration

## Testing
- pytest -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942fcb6c1488321be792a2a12d06c03)