### PR TITLE
Bereinige doppelte Benutzer-E-Mails bei der Sanitisierung

### DIFF
--- a/advent.py
+++ b/advent.py
@@ -132,6 +132,7 @@ def sanitize_user_records(connection):
         for row in rows
         if normalise_email(row["email"])
     }
+    seen_emails = set()
 
     sanitized = 0
 
@@ -147,9 +148,17 @@ def sanitize_user_records(connection):
             email = generate_placeholder_email(existing_emails, row["id"])
             needs_update = True
         else:
-            existing_emails.add(email)
-            if raw_email != email:
+            if email in seen_emails:
+                email = generate_placeholder_email(existing_emails, row["id"])
                 needs_update = True
+                logging.info(
+                    "Benutzer %s erhielt eine Platzhalter-E-Mail wegen Duplikat.",
+                    row["id"],
+                )
+            elif raw_email != email:
+                needs_update = True
+        existing_emails.add(email)
+        seen_emails.add(email)
 
         if not display_name:
             display_name = email or f"Benutzer {row['id']}"


### PR DESCRIPTION
### Motivation
- Duplikate normalisierter E‑Mail-Adressen sollen während der Benutzerdaten-Bereinigung erkannt und behandelt werden.
- Vergebene Platzhalter-E‑Mails müssen so reserviert werden, dass keine weiteren Kollisionen entstehen.

### Description
- In `sanitize_user_records` wurde ein Set `seen_emails` hinzugefügt, um bereits vergebene normalisierte E‑Mails nachzuverfolgen.
- Wenn eine normalisierte `email` bereits in `seen_emails` vorkommt, wird eine Platzhalter-E‑Mail über `generate_placeholder_email` erzeugt und `needs_update = True` gesetzt.
- `existing_emails` und `seen_emails` werden nach Vergabe konsistent aktualisiert und es wurde ein `logging.info`-Eintrag ergänzt, wenn ein Datensatz eine Platzhalter-E‑Mail wegen eines Duplikats erhält.

### Testing
- Es wurde `pytest` ausgeführt und alle automatisierten Tests erfolgreich abgeschlossen.
- Testlauf: `pytest` — Ergebnis: 7 tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695845ceaca08321b69266c30bf27eda)