### PR TITLE
Schütze QR-Code-Zugriffe anhand von `user_rewards`

### DIFF
--- a/advent.py
+++ b/advent.py
@@ -1976,14 +1976,64 @@ def oeffne_tuerchen(tag):
 @app.route('/download_qr/<filename>', methods=['GET'])
 def download_qr(filename):
     if DEBUG: logging.debug(f"Download-Anfrage für QR-Code: {filename}")
-    if not session.get('user_id'):
+    user_id = session.get('user_id')
+    if not user_id:
         return redirect(url_for('login'))
+    user = get_user_by_id(user_id)
+    if not user:
+        session.clear()
+        return redirect(url_for('login'))
+    if not is_admin_user(user):
+        with get_db_connection() as connection:
+            cursor = connection.execute(
+                "SELECT 1 FROM user_rewards WHERE user_id = ? AND qr_filename = ? LIMIT 1",
+                (user_id, filename),
+            )
+            if not cursor.fetchone():
+                if DEBUG:
+                    logging.debug(
+                        "QR-Code Zugriff verweigert für Benutzer %s (Datei: %s)",
+                        user_id,
+                        filename,
+                    )
+                return make_response(
+                    render_template_string(
+                        GENERIC_PAGE,
+                        content="Zugriff auf diesen QR-Code ist nicht erlaubt.",
+                    ),
+                    403,
+                )
     return send_from_directory('qr_codes', filename, as_attachment=True)
 
 @app.route('/qr_codes/<filename>')
 def qr_code(filename):
-    if not session.get('user_id'):
+    user_id = session.get('user_id')
+    if not user_id:
         return redirect(url_for('login'))
+    user = get_user_by_id(user_id)
+    if not user:
+        session.clear()
+        return redirect(url_for('login'))
+    if not is_admin_user(user):
+        with get_db_connection() as connection:
+            cursor = connection.execute(
+                "SELECT 1 FROM user_rewards WHERE user_id = ? AND qr_filename = ? LIMIT 1",
+                (user_id, filename),
+            )
+            if not cursor.fetchone():
+                if DEBUG:
+                    logging.debug(
+                        "QR-Code Anzeige verweigert für Benutzer %s (Datei: %s)",
+                        user_id,
+                        filename,
+                    )
+                return make_response(
+                    render_template_string(
+                        GENERIC_PAGE,
+                        content="Zugriff auf diesen QR-Code ist nicht erlaubt.",
+                    ),
+                    403,
+                )
     return send_from_directory('qr_codes', filename)
 
 # Route für das Ausliefern von Event-Graphen hinzufügen


### PR DESCRIPTION
### Motivation
- Sicherstellen, dass Nutzer nur QR-Codes herunterladen/anzeigen können, die ihnen in `user_rewards` zugeordnet sind.
- Unautorisierte Zugriffe auf Dateien in `qr_codes` verhindern.
- Administratoren weiterhin vollen Zugriff erlauben.
- Bei ungültiger Session oder fehlender Zuordnung mit Redirect oder `403` reagieren.

### Description
- `download_qr` und `qr_code` lesen `user_id` aus der `session` und validieren den Benutzer mit `get_user_by_id`.
- Für Nicht-Admins wird mit `get_db_connection()` die Abfrage `SELECT 1 FROM user_rewards WHERE user_id = ? AND qr_filename = ? LIMIT 1` ausgeführt und der Zugriff verweigert, falls kein Treffer vorliegt.
- Bei fehlendem oder ungültigem Benutzer wird die Session bereinigt und zu `login` weitergeleitet, und bei unberechtigtem Zugriff wird eine `403`-Seite mit `render_template_string(GENERIC_PAGE, ...)` zurückgegeben.
- Admins werden durch `is_admin_user(user)` vom Ownership-Check ausgenommen und behalten Zugriff auf alle QR-Codes.

### Testing
- Ausgeführt: `pytest -q`.
- Ergebnis: Alle Tests erfolgreich, `7 passed` (Dauer ~0.72s).
- Es wurden keine zusätzlichen automatisierten Tests hinzugefügt oder geändert.
- Die Änderungen wurden lokal ausgeführt und die Test-Suite lief grün.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695845da00808321a3428a0c907afbd3)