### PR TITLE
Gewinnablauf in oeffne_tuerchen transaktional refaktoriert

### DIFF
--- a/advent.py
+++ b/advent.py
@@ -1387,6 +1387,38 @@ def reduce_prize(prizes, current_day=None):
     return selected
 
 
+def waehle_preis_ohne_persistenz(prizes, current_day=None):
+    verfuegbare_preise = []
+    for index, preis in enumerate(prizes):
+        if preis.get("remaining", 0) <= 0:
+            continue
+        if index == 0 and current_day not in (None, 24):
+            continue
+        verfuegbare_preise.append((index, preis))
+
+    if not verfuegbare_preise:
+        return None, None
+
+    gewichte = [preis.get("remaining", 0) for _, preis in verfuegbare_preise]
+    ausgewaehlt_index, ausgewaehlter_preis = random.choices(
+        verfuegbare_preise,
+        weights=gewichte,
+        k=1,
+    )[0]
+    return ausgewaehlt_index, ausgewaehlter_preis
+
+
+def persistiere_preisreduzierung(prizes, preis_index):
+    if preis_index is None or preis_index < 0 or preis_index >= len(prizes):
+        return False
+    if prizes[preis_index].get("remaining", 0) <= 0:
+        return False
+
+    prizes[preis_index]["remaining"] -= 1
+    save_prizes(prizes)
+    return True
+
+
 def format_prize_lines(prizes):
     lines = []
     for prize in prizes:
@@ -1580,6 +1612,101 @@ def speichere_gewinner(user_identifier, display_name, tag, preis, jahr=None, spo
         file.write(
             f"{user_identifier}:{display_name} - Tag {tag} - {preis}{sponsor_text} - OV L11 - {jahr}\n"
         )
+
+
+def process_win_for_user(user_id, display_name, tag, heute, prizes):
+    error_message = (
+        "Leider ist beim Speichern deines Gewinns ein Fehler aufgetreten. "
+        "Bitte versuche es erneut oder kontaktiere uns zur Bestätigung."
+    )
+
+    preis_index, gewonnener_preis = waehle_preis_ohne_persistenz(prizes, heute.day)
+    if gewonnener_preis is None or not gewonnener_preis.get("name"):
+        hinweis = "Alle Preise wurden bereits vergeben."
+        if tag != 24 and prizes and prizes[0].get("remaining", 0) > 0:
+            hinweis = (
+                "Alle heutigen Preise wurden bereits vergeben. "
+                "Der Hauptpreis wird erst am 24. Dezember verlost."
+            )
+        return {"success": False, "status_code": 200, "message": hinweis}
+
+    aktuelles_jahr = heute.year
+    preis_name = str(gewonnener_preis.get("name", "") or "").strip()
+    sponsor_name = str(gewonnener_preis.get("sponsor", "") or "").strip()
+    sponsor_link = str(gewonnener_preis.get("sponsor_link", "") or "").strip()
+    qr_content = f"{tag}-{display_name}-{user_id}-{preis_name}-OV L11-{aktuelles_jahr}"
+    qr_filename = f"user_{user_id}_{tag}.png"
+    qr_pfad = os.path.join("qr_codes", qr_filename)
+
+    try:
+        qr = qrcode.QRCode(
+            version=1,
+            error_correction=qrcode.constants.ERROR_CORRECT_L,
+            box_size=10,
+            border=4,
+        )
+        qr.add_data(qr_content)
+        qr.make(fit=True)
+        img = qr.make_image(fill_color="black", back_color="white")
+        os.makedirs("qr_codes", exist_ok=True)
+        img.save(qr_pfad)
+    except Exception as exc:
+        logging.error("QR-Code konnte nicht erstellt werden: %s", exc)
+        return {"success": False, "status_code": 500, "message": error_message}
+
+    try:
+        reward_recorded = record_user_reward(
+            user_id,
+            tag,
+            preis_name,
+            sponsor=sponsor_name,
+            sponsor_link=sponsor_link,
+            qr_filename=qr_filename,
+            qr_content=qr_content,
+        )
+    except ValueError as exc:
+        logging.error("Ungültige Gewinninformationen: %s", exc)
+        reward_recorded = False
+    except Exception as exc:  # pragma: no cover - defensive logging path
+        logging.error("Beim Speichern des Gewinns ist ein Fehler aufgetreten: %s", exc)
+        reward_recorded = False
+
+    if not reward_recorded:
+        try:
+            if os.path.exists(qr_pfad):
+                os.remove(qr_pfad)
+        except OSError as exc:
+            logging.error("QR-Code %s konnte nicht entfernt werden: %s", qr_pfad, exc)
+        return {"success": False, "status_code": 500, "message": error_message}
+
+    if not persistiere_preisreduzierung(prizes, preis_index):
+        logging.error("Preisbestand konnte für Benutzer %s nicht aktualisiert werden.", user_id)
+        return {"success": False, "status_code": 500, "message": error_message}
+
+    try:
+        speichere_gewinner(
+            user_id,
+            display_name,
+            tag,
+            preis_name,
+            jahr=aktuelles_jahr,
+            sponsor=sponsor_name,
+        )
+        increment_daily_awarded_prizes(heute)
+    except Exception as exc:
+        logging.error("Gewinnerdaten konnten nicht vollständig gespeichert werden: %s", exc)
+        prizes[preis_index]["remaining"] += 1
+        save_prizes(prizes)
+        return {"success": False, "status_code": 500, "message": error_message}
+
+    return {
+        "success": True,
+        "status_code": 200,
+        "prize_name": preis_name,
+        "sponsor_name": sponsor_name,
+        "sponsor_link": sponsor_link,
+        "qr_filename": qr_filename,
+    }
 
 @app.route('/login', methods=['GET', 'POST'])
 @csrf.exempt
@@ -1885,70 +2012,17 @@ def oeffne_tuerchen(tag):
             and get_local_datetime().hour in gewinn_zeiten
             and random.random() < gewinnchance
         ):
-            gewonnener_preis = reduce_prize(prizes, heute.day)
-            if not gewonnener_preis or not gewonnener_preis.get("name"):
-                if DEBUG: logging.debug("Preis konnte nicht reduziert werden")
-                hinweis = "Alle Preise wurden bereits vergeben."
-                if tag != 24 and prizes and prizes[0].get("remaining", 0) > 0:
-                    hinweis = (
-                        "Alle heutigen Preise wurden bereits vergeben. "
-                        "Der Hauptpreis wird erst am 24. Dezember verlost."
-                    )
-                return make_response(render_template_string(GENERIC_PAGE, content=hinweis))
-            increment_daily_awarded_prizes(heute)
-            aktuelles_jahr = heute.year
-            preis_name = gewonnener_preis.get("name", "")
-            sponsor_name = str(gewonnener_preis.get("sponsor", "") or "").strip()
-            sponsor_link = str(gewonnener_preis.get("sponsor_link", "") or "").strip()
-            speichere_gewinner(user_id, display_name, tag, preis_name, jahr=aktuelles_jahr, sponsor=sponsor_name)
-            error_message = (
-                "Leider ist beim Speichern deines Gewinns ein Fehler aufgetreten. "
-                "Bitte versuche es erneut oder kontaktiere uns zur Bestätigung."
-            )
-
-            qr_content = f"{tag}-{display_name}-{user_id}-{preis_name}-OV L11-{aktuelles_jahr}"
-            try:
-                qr = qrcode.QRCode(
-                    version=1,
-                    error_correction=qrcode.constants.ERROR_CORRECT_L,
-                    box_size=10,
-                    border=4,
-                )
-                qr.add_data(qr_content)
-                qr.make(fit=True)
-                img = qr.make_image(fill_color="black", back_color="white")
-                qr_filename = f"user_{user_id}_{tag}.png"
-                os.makedirs('qr_codes', exist_ok=True)
-                img.save(os.path.join('qr_codes', qr_filename))  # Speicherort korrigiert
-                if DEBUG: logging.debug(f"QR-Code generiert und gespeichert: {qr_filename}")
-            except Exception as exc:
-                logging.error("QR-Code konnte nicht erstellt werden: %s", exc)
+            result = process_win_for_user(user_id, display_name, tag, heute, prizes)
+            if not result.get("success"):
                 return make_response(
-                    render_template_string(GENERIC_PAGE, content=error_message),
-                    500,
+                    render_template_string(GENERIC_PAGE, content=result.get("message", "")),
+                    result.get("status_code", 500),
                 )
-            try:
-                reward_recorded = record_user_reward(
-                    user_id,
-                    tag,
-                    preis_name,
-                    sponsor=sponsor_name,
-                    sponsor_link=sponsor_link,
-                    qr_filename=qr_filename,
-                    qr_content=qr_content,
-                )
-            except ValueError as exc:
-                logging.error("Ungültige Gewinninformationen: %s", exc)
-                reward_recorded = False
-            except Exception as exc:  # pragma: no cover - defensive logging path
-                logging.error("Beim Speichern des Gewinns ist ein Fehler aufgetreten: %s", exc)
-                reward_recorded = False
+            preis_name = result.get("prize_name", "")
+            sponsor_name = result.get("sponsor_name", "")
+            sponsor_link = result.get("sponsor_link", "")
+            qr_filename = result.get("qr_filename", "")
 
-            if not reward_recorded:
-                return make_response(
-                    render_template_string(GENERIC_PAGE, content=error_message),
-                    500,
-                )
             prize_label = escape(preis_name)
             sponsor_hint = Markup("")
             if sponsor_name:

--- a/test_oeffne_tuerchen_failures.py
+++ b/test_oeffne_tuerchen_failures.py
@@ -1,4 +1,6 @@
 import datetime
+import json
+import os
 import sqlite3
 
 import pytz
@@ -7,8 +9,16 @@ import advent
 
 
 def _prepare_winning_request(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     database_path = tmp_path / "users.db"
+    winners_path = tmp_path / "gewinner.txt"
+    prizes_path = tmp_path / "preise.json"
+    daily_counter_path = tmp_path / "tagespreise.json"
+
     monkeypatch.setattr(advent, "USER_DATABASE", str(database_path))
+    monkeypatch.setattr(advent, "WINNERS_FILE", str(winners_path))
+    monkeypatch.setattr(advent, "PRIZE_FILE", str(prizes_path))
+    monkeypatch.setattr(advent, "DAILY_PRIZE_FILE", str(daily_counter_path))
     advent.init_user_db()
 
     with sqlite3.connect(database_path) as connection:
@@ -16,32 +26,32 @@ def _prepare_winning_request(tmp_path, monkeypatch):
             "INSERT INTO users (id, email, display_name, password_hash) VALUES (1, 'test@example.com', 'Tester', '')"
         )
 
-    fake_now = datetime.datetime(2023, 12, 5, 12, 0, tzinfo=pytz.utc)
-    monkeypatch.setattr(advent, "get_local_datetime", lambda: fake_now)
-    monkeypatch.setattr(advent, "get_calendar_active", lambda: True)
-    monkeypatch.setattr(advent, "hat_teilgenommen", lambda *_, **__: False)
-    monkeypatch.setattr(advent, "speichere_teilnehmer", lambda *_, **__: None)
-    monkeypatch.setattr(
-        advent,
-        "get_prize_stats",
-        lambda: (
+    with open(prizes_path, "w", encoding="utf-8") as datei:
+        json.dump(
             [
                 {
                     "name": "Testpreis",
+                    "total": 1,
                     "remaining": 1,
                     "sponsor": "Sponsor",
                     "sponsor_link": "https://example.com",
                 }
             ],
-            1,
-            1,
-            None,
-        ),
-    )
+            datei,
+            ensure_ascii=False,
+            indent=2,
+        )
+
+    fake_now = datetime.datetime(2023, 12, 5, 12, 0, tzinfo=pytz.utc)
+    monkeypatch.setattr(advent, "get_local_datetime", lambda: fake_now)
+    monkeypatch.setattr(advent, "get_calendar_active", lambda: True)
+    monkeypatch.setattr(advent, "hat_teilgenommen", lambda *_, **__: False)
+    monkeypatch.setattr(advent, "speichere_teilnehmer", lambda *_, **__: None)
+    originale_get_prize_stats = advent.get_prize_stats
+    monkeypatch.setattr(advent, "get_prize_stats", lambda: originale_get_prize_stats(advent.load_prizes()))
     monkeypatch.setattr(advent, "verbleibende_tage_bis_letztes_tuerchen", lambda _date: 1)
-    monkeypatch.setattr(advent, "increment_daily_awarded_prizes", lambda *_, **__: None)
     monkeypatch.setattr(advent, "gewinnchance_ermitteln", lambda *_, **__: 1.0)
-    monkeypatch.setattr(advent, "reduce_prize", lambda prizes, _day: prizes[0])
+    monkeypatch.setattr(advent, "waehle_preis_ohne_persistenz", lambda prizes, _day: (0, prizes[0]))
     monkeypatch.setattr(advent.random, "random", lambda: 0.0)
 
     advent.tuerchen_status.clear()
@@ -51,11 +61,32 @@ def _prepare_winning_request(tmp_path, monkeypatch):
     with client.session_transaction() as session:
         session["user_id"] = 1
 
-    return client
+    return client, prizes_path, daily_counter_path, winners_path
+
+
+def _load_prize_remaining(prizes_path):
+    with open(prizes_path, "r", encoding="utf-8") as datei:
+        data = json.load(datei)
+    return data[0]["remaining"]
+
+
+def _reward_count(database_path):
+    with sqlite3.connect(database_path) as verbindung:
+        return verbindung.execute("SELECT COUNT(*) FROM user_rewards").fetchone()[0]
+
+
+def _daily_counter(daily_counter_path, date_key):
+    if not daily_counter_path.exists():
+        return 0
+    with open(daily_counter_path, "r", encoding="utf-8") as datei:
+        data = json.load(datei)
+    return data.get("awards", {}).get(date_key, 0)
 
 
 def test_user_reward_failure_returns_error_page(monkeypatch, tmp_path):
-    client = _prepare_winning_request(tmp_path, monkeypatch)
+    client, prizes_path, daily_counter_path, winners_path = _prepare_winning_request(tmp_path, monkeypatch)
+    database_path = tmp_path / "users.db"
+    today_key = "2023-12-05"
     monkeypatch.setattr(advent, "record_user_reward", lambda *_, **__: False)
 
     response = client.get("/oeffne_tuerchen/5")
@@ -64,10 +95,16 @@ def test_user_reward_failure_returns_error_page(monkeypatch, tmp_path):
     assert response.status_code == 500
     assert "Fehler" in body
     assert "Gl\u00fcckwunsch" not in body
+    assert _load_prize_remaining(prizes_path) == 1
+    assert _daily_counter(daily_counter_path, today_key) == 0
+    assert not winners_path.exists()
+    assert _reward_count(database_path) == 0
 
 
 def test_user_reward_exception_returns_error_page(monkeypatch, tmp_path):
-    client = _prepare_winning_request(tmp_path, monkeypatch)
+    client, prizes_path, daily_counter_path, winners_path = _prepare_winning_request(tmp_path, monkeypatch)
+    database_path = tmp_path / "users.db"
+    today_key = "2023-12-05"
 
     def _raise_error(*_, **__):
         raise sqlite3.DatabaseError("boom")
@@ -80,3 +117,30 @@ def test_user_reward_exception_returns_error_page(monkeypatch, tmp_path):
     assert response.status_code == 500
     assert "Fehler" in body
     assert "Gl\u00fcckwunsch" not in body
+    assert _load_prize_remaining(prizes_path) == 1
+    assert _daily_counter(daily_counter_path, today_key) == 0
+    assert not winners_path.exists()
+    assert _reward_count(database_path) == 0
+
+
+def test_qr_error_rolls_back_without_persistent_changes(monkeypatch, tmp_path):
+    client, prizes_path, daily_counter_path, winners_path = _prepare_winning_request(tmp_path, monkeypatch)
+    database_path = tmp_path / "users.db"
+    today_key = "2023-12-05"
+
+    class FehlerhafteQRCode:
+        def __init__(self, *_, **__):
+            raise RuntimeError("kein qr")
+
+    monkeypatch.setattr(advent.qrcode, "QRCode", FehlerhafteQRCode)
+
+    response = client.get("/oeffne_tuerchen/5")
+    body = response.get_data(as_text=True)
+
+    assert response.status_code == 500
+    assert "Fehler" in body
+    assert _load_prize_remaining(prizes_path) == 1
+    assert _daily_counter(daily_counter_path, today_key) == 0
+    assert not winners_path.exists()
+    assert not os.path.exists("qr_codes/user_1_5.png")
+    assert _reward_count(database_path) == 0

--- a/test_user_rewards_unique_index.py
+++ b/test_user_rewards_unique_index.py
@@ -66,7 +66,8 @@ def test_oeffne_tuerchen_migrates_user_rewards_index(tmp_path, monkeypatch):
     monkeypatch.setattr(advent, "verbleibende_tage_bis_letztes_tuerchen", lambda _date: 1)
     monkeypatch.setattr(advent, "increment_daily_awarded_prizes", lambda *_, **__: None)
     monkeypatch.setattr(advent, "gewinnchance_ermitteln", lambda *_, **__: 1.0)
-    monkeypatch.setattr(advent, "reduce_prize", lambda prizes, _day: prizes[0])
+    monkeypatch.setattr(advent, "waehle_preis_ohne_persistenz", lambda prizes, _day: (0, prizes[0]))
+    monkeypatch.setattr(advent, "persistiere_preisreduzierung", lambda *_, **__: True)
     monkeypatch.setattr(advent.random, "random", lambda: 0.0)
 
     advent.tuerchen_status.clear()
@@ -151,7 +152,8 @@ def test_oeffne_tuerchen_without_unique_constraint_falls_back(tmp_path, monkeypa
     monkeypatch.setattr(advent, "verbleibende_tage_bis_letztes_tuerchen", lambda _date: 1)
     monkeypatch.setattr(advent, "increment_daily_awarded_prizes", lambda *_, **__: None)
     monkeypatch.setattr(advent, "gewinnchance_ermitteln", lambda *_, **__: 1.0)
-    monkeypatch.setattr(advent, "reduce_prize", lambda prizes, _day: prizes[0])
+    monkeypatch.setattr(advent, "waehle_preis_ohne_persistenz", lambda prizes, _day: (0, prizes[0]))
+    monkeypatch.setattr(advent, "persistiere_preisreduzierung", lambda *_, **__: True)
     monkeypatch.setattr(advent.random, "random", lambda: 0.0)
     monkeypatch.setattr(advent, "ensure_user_rewards_unique_constraint", lambda _conn: False)
 


### PR DESCRIPTION
### Motivation

- Die Gewinnverarbeitung in `oeffne_tuerchen()` sollte atomarer und übersichtlicher werden, sodass Datenvorbereitung und Persistenz klar getrennt sind und Fehlerpfade keine Teiländerungen hinterlassen.

### Description

- Die Gewinnauswahl wurde in zwei Schritte aufgeteilt: `waehle_preis_ohne_persistenz(prizes, ...)` zur reinen Auswahl ohne Schreiben und `persistiere_preisreduzierung(prizes, index)` zur expliziten Bestandsreduktion und Speicherung in `preise.json`.
- Die komplette Gewinnverarbeitung wurde in die neue Hilfsfunktion `process_win_for_user(user_id, display_name, tag, heute, prizes)` ausgelagert, die ein strukturiertes Ergebnis (`success`, `status_code`, `message`/Gewinndaten) liefert.
- QR-Erzeugung erfolgt vor der dauerhaften Persistenz; schlägt die DB-Persistenz fehl, wird die erzeugte QR-Datei gelöscht, und es werden keine dauerhaften Teiländerungen (DB-Eintrag, Gewinnerdatei, Tageszähler, Preisbestand) zurückgelassen.
- Die Route `oeffne_tuerchen()` wurde vereinfacht und rendert nun nur noch anhand des Rückgabewerts von `process_win_for_user()`; bestehende Hilfsfunktionen (`speichere_gewinner`, `record_user_reward`, `increment_daily_awarded_prizes`) bleiben erhalten und werden in klarer Reihenfolge genutzt.

### Testing

- `pytest -q test_oeffne_tuerchen_failures.py` wurde ausgeführt und bestanden (`3 passed`).
- Die betroffenen Migrations-/Fallback-Tests in `test_user_rewards_unique_index.py` wurden angepasst und die gesamte Test-Suite erfolgreich ausgeführt (`pytest -q` → `8 passed`).
- Während der Arbeit traten anfängliche Testfehler durch veraltete Test-Mocks auf, die behoben wurden; alle automatisierten Tests sind nach den Änderungen grün.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e87948709c8321b4c981b9f4453992)