### PR TITLE
DB-basierte Gewinnprüfung in hat_gewonnen mit Legacy-Mapping-Fallback

### DIFF
--- a/advent.py
+++ b/advent.py
@@ -1527,18 +1527,73 @@ def parse_prize_configuration(prize_data):
 def hat_gewonnen(user_identifier):
     """Überprüft, ob der Benutzer bereits gewonnen hat."""
     user_identifier = str(user_identifier)
+    user_identifier_int = None
+    try:
+        user_identifier_int = int(user_identifier)
+    except (TypeError, ValueError):
+        pass
+
+    user_lookup = {"by_id": {}, "by_email": {}, "by_display": {}}
+    winner_mappings = []
+
+    try:
+        with get_db_connection() as connection:
+            cursor = connection.execute(
+                "SELECT 1 FROM user_rewards WHERE user_id = ? LIMIT 1",
+                (user_identifier,),
+            )
+            if cursor.fetchone():
+                return True
+
+            user_lookup = build_user_lookup(connection)
+            winner_mappings = load_winner_user_mapping(WINNER_USER_MAPPING_FILE)
+    except sqlite3.DatabaseError as exc:
+        logging.error("Gewinnstatus konnte nicht aus der Datenbank geprüft werden: %s", exc)
+
     winners_file_path = os.path.abspath(WINNERS_FILE)
     if not os.path.exists(winners_file_path):
         return False
+
     with open(winners_file_path, "r", encoding="utf-8") as file:
         for line in file:
             line = line.strip()
             if not line:
                 continue
+
             prefix = line.split(" ", 1)[0]
             prefix_id = prefix.split(":", 1)[0]
             if prefix_id == user_identifier:
                 return True
+
+            if user_identifier_int is None:
+                continue
+
+            parsed_entry = parse_winner_entry(line)
+            mapped_user_id = None
+
+            if parsed_entry:
+                mapped_user_id = resolve_user_id_from_identity(
+                    user_lookup,
+                    winner_mappings,
+                    winner_id=parsed_entry.get("user_id"),
+                    email=parsed_entry.get("email"),
+                    display_name=parsed_entry.get("display_name"),
+                )
+            else:
+                try:
+                    legacy_winner_id = int(prefix_id)
+                except ValueError:
+                    legacy_winner_id = None
+                if legacy_winner_id is not None:
+                    mapped_user_id = resolve_user_id_from_identity(
+                        user_lookup,
+                        winner_mappings,
+                        winner_id=legacy_winner_id,
+                    )
+
+            if mapped_user_id == user_identifier_int:
+                return True
+
     return False
 
 

--- a/test_hat_gewonnen_db_fallback.py
+++ b/test_hat_gewonnen_db_fallback.py
@@ -1,0 +1,76 @@
+import sqlite3
+
+import advent
+
+
+def create_default_schema(connection):
+    connection.execute(
+        """
+        CREATE TABLE users (
+            id INTEGER PRIMARY KEY,
+            email TEXT UNIQUE NOT NULL,
+            display_name TEXT NOT NULL,
+            password_hash TEXT NOT NULL
+        )
+        """
+    )
+    connection.execute(advent.USER_REWARDS_TABLE_SQL)
+
+
+def test_hat_gewonnen_findet_direkten_datenbankgewinn(tmp_path, monkeypatch):
+    database_path = tmp_path / "users.db"
+    winners_file = tmp_path / "gewinner.txt"
+    mapping_file = tmp_path / "gewinner_user_mapping.json"
+    winners_file.write_text("", encoding="utf-8")
+    mapping_file.write_text("[]", encoding="utf-8")
+
+    monkeypatch.setattr(advent, "USER_DATABASE", str(database_path))
+    monkeypatch.setattr(advent, "WINNERS_FILE", str(winners_file))
+    monkeypatch.setattr(advent, "WINNER_USER_MAPPING_FILE", str(mapping_file))
+
+    with sqlite3.connect(database_path) as connection:
+        connection.row_factory = sqlite3.Row
+        create_default_schema(connection)
+        connection.execute(
+            "INSERT INTO users (id, email, display_name, password_hash) VALUES (?, ?, ?, ?)",
+            (7, "test7@example.com", "Test 7", ""),
+        )
+        connection.execute(
+            """
+            INSERT INTO user_rewards (
+                user_id, door, prize_name, sponsor, sponsor_link, qr_filename, qr_content, created_at
+            ) VALUES (?, ?, ?, NULL, NULL, NULL, NULL, datetime('now'))
+            """,
+            (7, 3, "Preis"),
+        )
+
+    assert advent.hat_gewonnen(7) is True
+
+
+def test_hat_gewonnen_fallback_mit_mapping_auf_echte_user_id(tmp_path, monkeypatch):
+    database_path = tmp_path / "users.db"
+    winners_file = tmp_path / "gewinner.txt"
+    mapping_file = tmp_path / "gewinner_user_mapping.json"
+
+    winners_file.write_text(
+        "99:Legacy User - Tag 5 - Nostalgiepreis - OV L11 - 2025\n",
+        encoding="utf-8",
+    )
+    mapping_file.write_text(
+        '[{"winner_id": 99, "user_id": 1, "display_name": "Real User"}]',
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(advent, "USER_DATABASE", str(database_path))
+    monkeypatch.setattr(advent, "WINNERS_FILE", str(winners_file))
+    monkeypatch.setattr(advent, "WINNER_USER_MAPPING_FILE", str(mapping_file))
+
+    with sqlite3.connect(database_path) as connection:
+        connection.row_factory = sqlite3.Row
+        create_default_schema(connection)
+        connection.execute(
+            "INSERT INTO users (id, email, display_name, password_hash) VALUES (?, ?, ?, ?)",
+            (1, "real@example.com", "Real User", ""),
+        )
+
+    assert advent.hat_gewonnen(1) is True


### PR DESCRIPTION
### Motivation
- `hat_gewonnen` soll zuverlässiger auf aktuelle Daten prüfen und alte `gewinner.txt`-Einträge nur noch als Legacy-Fallback behandeln.
- Alte Placeholder-IDs aus `gewinner.txt` müssen auf reale Benutzer aufgelöst werden, damit Migrations-/Importfälle korrekt erkannt werden.

### Description
- `hat_gewonnen` prüft nun primär die Datenbank mit `SELECT 1 FROM user_rewards WHERE user_id = ? LIMIT 1` und gibt `True` zurück, wenn ein Treffer existiert.
- Falls kein Datenbanktreffer vorliegt, wird `gewinner.txt` als Fallback gelesen und Einträge über `parse_winner_entry`, `load_winner_user_mapping(...)` und `resolve_user_id_from_identity(...)` auf echte Benutzer-IDs aufgelöst.
- Beim Fallback werden sowohl vollständig geparste Legacy-Einträge als auch einfache legacy-IDs berücksichtigt und gegen die aufgelöste `user_id` verglichen.
- Dateien geändert/neu: `advent.py` (Logik erweitert) und neuer Test `test_hat_gewonnen_db_fallback.py` (zwei Tests für direkte DB-Treffer und gemappte Legacy-IDs).

### Testing
- Neue Tests in `test_hat_gewonnen_db_fallback.py` wurden hinzugefügt und decken direkten Datenbankgewinn sowie Legacy-Fallback mit Mapping ab.
- Die gesamte Test-Suite wurde mit `pytest -q` ausgeführt und alle Tests wurden erfolgreich bestanden (`10 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8c4aeb1fc8321a9aa6909a749d16a)